### PR TITLE
feat: 不動産業者システムの基盤実装（Phase 1）

### DIFF
--- a/app/models/inquiry.rb
+++ b/app/models/inquiry.rb
@@ -1,0 +1,60 @@
+class Inquiry < ApplicationRecord
+  # アソシエーション
+  belongs_to :property
+  belongs_to :buyer, class_name: 'User'
+  belongs_to :agent, class_name: 'User'
+
+  # ステータスの定義
+  enum :status, {
+    pending: 0,     # 問い合わせ待ち
+    contacted: 1,   # 連絡済み
+    closed: 2       # 完了
+  }
+
+  # バリデーション
+  validates :property_id, presence: true
+  validates :buyer_id, presence: true
+  validates :agent_id, presence: true
+  validates :message, presence: true, length: { maximum: 2000 }
+  validates :buyer_id, uniqueness: { scope: :property_id }
+
+  # カスタムバリデーション
+  validate :validate_user_types
+
+  # スコープ
+  scope :pending, -> { where(status: :pending) }
+  scope :contacted, -> { where(status: :contacted) }
+  scope :for_agent, ->(agent_id) { where(agent_id: agent_id) }
+  scope :for_property, ->(property_id) { where(property_id: property_id) }
+  scope :recent, -> { order(created_at: :desc) }
+
+  # メソッド
+  def mark_contacted!
+    update!(status: :contacted, contacted_at: Time.current)
+  end
+
+  def mark_closed!
+    update!(status: :closed, closed_at: Time.current)
+  end
+
+  def response_time_hours
+    return 0 unless contacted_at
+    ((contacted_at - created_at) / 1.hour).round(1)
+  end
+
+  def days_since_inquiry
+    ((Time.current - created_at) / 1.day).round
+  end
+
+  private
+
+  def validate_user_types
+    if buyer && !buyer.buyer?
+      errors.add(:buyer, 'は一般ユーザーである必要があります')
+    end
+    
+    if agent && !agent.agent?
+      errors.add(:agent, 'は不動産業者である必要があります')
+    end
+  end
+end

--- a/app/models/membership_plan.rb
+++ b/app/models/membership_plan.rb
@@ -1,0 +1,30 @@
+class MembershipPlan < ApplicationRecord
+  # アソシエーション
+  has_many :users, dependent: :nullify
+
+  # バリデーション
+  validates :name, presence: true, length: { maximum: 100 }
+  validates :monthly_owner_limit, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :monthly_price, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :sort_order, numericality: { greater_than_or_equal_to: 0 }
+
+  # スコープ
+  scope :active, -> { where(active: true) }
+  scope :ordered, -> { order(:sort_order, :id) }
+
+  # features をJSONとして扱う
+  serialize :features, coder: JSON
+
+  # 表示用メソッド
+  def formatted_price
+    if monthly_price == 0
+      "無料"
+    else
+      "#{monthly_price.to_s.gsub(/(\d)(?=(\d{3})+(?!\d))/, '\1,')}円/月"
+    end
+  end
+
+  def features_list
+    features.is_a?(Array) ? features : []
+  end
+end

--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -1,0 +1,67 @@
+class Partnership < ApplicationRecord
+  # アソシエーション
+  belongs_to :agent, class_name: 'User'
+  belongs_to :owner, class_name: 'User'
+
+  # ステータスの定義
+  enum :status, {
+    pending: 0,    # 申請中
+    active: 1,     # 有効
+    inactive: 2,   # 無効
+    terminated: 3  # 終了
+  }
+
+  # バリデーション
+  validates :agent_id, presence: true
+  validates :owner_id, presence: true
+  validates :commission_rate, presence: true, 
+            numericality: { greater_than: 0, less_than_or_equal_to: 100 }
+  validates :agent_id, uniqueness: { scope: :owner_id }
+
+  # カスタムバリデーション
+  validate :validate_user_types
+  validate :validate_dates
+
+  # スコープ
+  scope :active, -> { where(status: :active) }
+  scope :pending, -> { where(status: :pending) }
+  scope :for_agent, ->(agent_id) { where(agent_id: agent_id) }
+  scope :for_owner, ->(owner_id) { where(owner_id: owner_id) }
+
+  # メソッド
+  def activate!
+    update!(status: :active, started_at: Time.current)
+  end
+
+  def terminate!
+    update!(status: :terminated, ended_at: Time.current)
+  end
+
+  def duration_days
+    return 0 unless started_at
+    end_date = ended_at || Time.current
+    ((end_date - started_at) / 1.day).round
+  end
+
+  def formatted_commission_rate
+    "#{commission_rate}%"
+  end
+
+  private
+
+  def validate_user_types
+    if agent && !agent.agent?
+      errors.add(:agent, 'は不動産業者である必要があります')
+    end
+    
+    if owner && !owner.owner?
+      errors.add(:owner, 'はオーナーである必要があります')
+    end
+  end
+
+  def validate_dates
+    if started_at && ended_at && started_at > ended_at
+      errors.add(:ended_at, 'は開始日より後である必要があります')
+    end
+  end
+end

--- a/db/migrate/20250815143613_create_membership_plans.rb
+++ b/db/migrate/20250815143613_create_membership_plans.rb
@@ -1,0 +1,17 @@
+class CreateMembershipPlans < ActiveRecord::Migration[8.0]
+  def change
+    create_table :membership_plans do |t|
+      t.string :name, null: false
+      t.integer :monthly_owner_limit, null: false, default: 0
+      t.integer :monthly_price, null: false, default: 0
+      t.text :features
+      t.boolean :active, null: false, default: true
+      t.integer :sort_order, default: 0
+
+      t.timestamps
+    end
+
+    add_index :membership_plans, :active
+    add_index :membership_plans, :sort_order
+  end
+end

--- a/db/migrate/20250815143621_create_partnerships.rb
+++ b/db/migrate/20250815143621_create_partnerships.rb
@@ -1,0 +1,19 @@
+class CreatePartnerships < ActiveRecord::Migration[8.0]
+  def change
+    create_table :partnerships do |t|
+      t.references :agent, null: false, foreign_key: { to_table: :users }
+      t.references :owner, null: false, foreign_key: { to_table: :users }
+      t.integer :status, null: false, default: 0
+      t.datetime :started_at
+      t.datetime :ended_at
+      t.decimal :commission_rate, precision: 5, scale: 2
+      t.text :terms
+
+      t.timestamps
+    end
+
+    add_index :partnerships, [:agent_id, :owner_id], unique: true
+    add_index :partnerships, :status
+    add_index :partnerships, :started_at
+  end
+end

--- a/db/migrate/20250815143627_create_inquiries.rb
+++ b/db/migrate/20250815143627_create_inquiries.rb
@@ -1,0 +1,19 @@
+class CreateInquiries < ActiveRecord::Migration[8.0]
+  def change
+    create_table :inquiries do |t|
+      t.references :property, null: false, foreign_key: true
+      t.references :buyer, null: false, foreign_key: { to_table: :users }
+      t.references :agent, null: false, foreign_key: { to_table: :users }
+      t.integer :status, null: false, default: 0
+      t.text :message
+      t.datetime :contacted_at
+      t.datetime :closed_at
+
+      t.timestamps
+    end
+
+    add_index :inquiries, :status
+    add_index :inquiries, :created_at
+    add_index :inquiries, [:property_id, :buyer_id], unique: true
+  end
+end

--- a/db/migrate/20250815143632_add_agent_fields_to_users.rb
+++ b/db/migrate/20250815143632_add_agent_fields_to_users.rb
@@ -1,0 +1,12 @@
+class AddAgentFieldsToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :users, :membership_plan, null: true, foreign_key: true
+    add_column :users, :company_name, :string
+    add_column :users, :license_number, :string
+    add_column :users, :monthly_message_count, :integer, default: 0
+    add_column :users, :message_count_reset_at, :datetime
+
+    add_index :users, :license_number, unique: true
+    # membership_plan_idのインデックスはadd_referenceで自動作成されるため削除
+  end
+end

--- a/db/migrate/20250815143724_add_agent_to_user_types.rb
+++ b/db/migrate/20250815143724_add_agent_to_user_types.rb
@@ -1,0 +1,7 @@
+class AddAgentToUserTypes < ActiveRecord::Migration[8.0]
+  def change
+    # user_typeのenumにagent(2)を追加するためのコメント
+    # Userモデルで enum :user_type, { buyer: 0, owner: 1, agent: 2, admin: 99 } に変更
+    # 既存データには影響なし（buyer=0, owner=1, admin=99はそのまま）
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_13_025231) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_15_143724) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -62,6 +62,37 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_13_025231) do
     t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
+  create_table "inquiries", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "property_id", null: false
+    t.bigint "buyer_id", null: false
+    t.bigint "agent_id", null: false
+    t.integer "status", default: 0, null: false
+    t.text "message"
+    t.datetime "contacted_at"
+    t.datetime "closed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["agent_id"], name: "index_inquiries_on_agent_id"
+    t.index ["buyer_id"], name: "index_inquiries_on_buyer_id"
+    t.index ["created_at"], name: "index_inquiries_on_created_at"
+    t.index ["property_id", "buyer_id"], name: "index_inquiries_on_property_id_and_buyer_id", unique: true
+    t.index ["property_id"], name: "index_inquiries_on_property_id"
+    t.index ["status"], name: "index_inquiries_on_status"
+  end
+
+  create_table "membership_plans", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "monthly_owner_limit", default: 0, null: false
+    t.integer "monthly_price", default: 0, null: false
+    t.text "features"
+    t.boolean "active", default: true, null: false
+    t.integer "sort_order", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active"], name: "index_membership_plans_on_active"
+    t.index ["sort_order"], name: "index_membership_plans_on_sort_order"
+  end
+
   create_table "messages", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "conversation_id", null: false
     t.bigint "sender_id", null: false
@@ -73,6 +104,23 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_13_025231) do
     t.index ["conversation_id"], name: "index_messages_on_conversation_id"
     t.index ["sender_id", "created_at"], name: "index_messages_on_sender_id_and_created_at"
     t.index ["sender_id"], name: "index_messages_on_sender_id"
+  end
+
+  create_table "partnerships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "agent_id", null: false
+    t.bigint "owner_id", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "started_at"
+    t.datetime "ended_at"
+    t.decimal "commission_rate", precision: 5, scale: 2
+    t.text "terms"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["agent_id", "owner_id"], name: "index_partnerships_on_agent_id_and_owner_id", unique: true
+    t.index ["agent_id"], name: "index_partnerships_on_agent_id"
+    t.index ["owner_id"], name: "index_partnerships_on_owner_id"
+    t.index ["started_at"], name: "index_partnerships_on_started_at"
+    t.index ["status"], name: "index_partnerships_on_status"
   end
 
   create_table "properties", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -132,7 +180,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_13_025231) do
     t.integer "user_type", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "membership_plan_id"
+    t.string "company_name"
+    t.string "license_number"
+    t.integer "monthly_message_count", default: 0
+    t.datetime "message_count_reset_at"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["license_number"], name: "index_users_on_license_number", unique: true
+    t.index ["membership_plan_id"], name: "index_users_on_membership_plan_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
@@ -143,9 +198,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_13_025231) do
   add_foreign_key "conversations", "users", column: "owner_id"
   add_foreign_key "favorites", "properties"
   add_foreign_key "favorites", "users"
+  add_foreign_key "inquiries", "properties"
+  add_foreign_key "inquiries", "users", column: "agent_id"
+  add_foreign_key "inquiries", "users", column: "buyer_id"
   add_foreign_key "messages", "conversations"
   add_foreign_key "messages", "users", column: "sender_id"
+  add_foreign_key "partnerships", "users", column: "agent_id"
+  add_foreign_key "partnerships", "users", column: "owner_id"
   add_foreign_key "properties", "users"
   add_foreign_key "property_tags", "properties"
   add_foreign_key "property_tags", "tags"
+  add_foreign_key "users", "membership_plans"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,8 +27,125 @@ else
   puts "   名前: #{admin_user.name}"
 end
 
+# 会員プランの作成
+puts "\n=== 会員プラン作成 ==="
+
+membership_plans = [
+  {
+    name: 'フリープラン',
+    monthly_owner_limit: 3,
+    monthly_price: 0,
+    features: ['月3人のオーナーにメッセージ可能', '基本的なプロフィール表示'],
+    sort_order: 1
+  },
+  {
+    name: 'ベーシックプラン',
+    monthly_owner_limit: 10,
+    monthly_price: 9800,
+    features: ['月10人のオーナーにメッセージ可能', '詳細プロフィール表示', 'お気に入り機能'],
+    sort_order: 2
+  },
+  {
+    name: 'プレミアムプラン',
+    monthly_owner_limit: 30,
+    monthly_price: 19800,
+    features: ['月30人のオーナーにメッセージ可能', 'プレミアムプロフィール表示', 'お気に入り機能', '優先サポート'],
+    sort_order: 3
+  },
+  {
+    name: 'エンタープライズプラン',
+    monthly_owner_limit: 100,
+    monthly_price: 49800,
+    features: ['月100人のオーナーにメッセージ可能', 'カスタムプロフィール表示', '全機能利用可能', '専任サポート', 'API利用'],
+    sort_order: 4
+  }
+]
+
+membership_plans.each do |plan_data|
+  plan = MembershipPlan.find_or_initialize_by(name: plan_data[:name])
+  
+  if plan.new_record?
+    plan.assign_attributes(plan_data)
+    if plan.save
+      puts "✅ #{plan.name}を作成しました（#{plan.formatted_price}）"
+    else
+      puts "❌ #{plan.name}の作成に失敗しました: #{plan.errors.full_messages.join(', ')}"
+    end
+  else
+    puts "⚠️  #{plan.name}は既に存在します"
+  end
+end
+
+# サンプル不動産業者の作成
+puts "\n=== サンプル不動産業者作成 ==="
+
+sample_agents = [
+  {
+    name: '田中太郎',
+    email: 'tanaka@sample-estate.com',
+    password: 'password123',
+    company_name: '田中不動産株式会社',
+    license_number: '東京都知事(1)第12345号',
+    membership_plan: MembershipPlan.find_by(name: 'ベーシックプラン')
+  },
+  {
+    name: '佐藤花子',
+    email: 'sato@premium-estate.com',
+    password: 'password123',
+    company_name: 'プレミアム不動産',
+    license_number: '東京都知事(2)第67890号',
+    membership_plan: MembershipPlan.find_by(name: 'プレミアムプラン')
+  }
+]
+
+sample_agents.each do |agent_data|
+  agent = User.find_or_initialize_by(email: agent_data[:email])
+  
+  if agent.new_record?
+    agent.assign_attributes(agent_data.merge(user_type: 'agent'))
+    if agent.save
+      puts "✅ #{agent.display_name}を作成しました"
+      puts "   免許番号: #{agent.license_number}"
+      puts "   プラン: #{agent.membership_plan.name}"
+    else
+      puts "❌ #{agent_data[:name]}の作成に失敗しました: #{agent.errors.full_messages.join(', ')}"
+    end
+  else
+    puts "⚠️  #{agent_data[:email]}は既に存在します"
+  end
+end
+
+# サンプルオーナーの作成
+puts "\n=== サンプルオーナー作成 ==="
+
+sample_owners = [
+  { name: '山田一郎', email: 'yamada@example.com', password: 'password123' },
+  { name: '鈴木二郎', email: 'suzuki@example.com', password: 'password123' }
+]
+
+sample_owners.each do |owner_data|
+  owner = User.find_or_initialize_by(email: owner_data[:email])
+  
+  if owner.new_record?
+    owner.assign_attributes(owner_data.merge(user_type: 'owner'))
+    if owner.save
+      puts "✅ #{owner.name}（オーナー）を作成しました"
+    else
+      puts "❌ #{owner_data[:name]}の作成に失敗しました: #{owner.errors.full_messages.join(', ')}"
+    end
+  else
+    puts "⚠️  #{owner_data[:email]}は既に存在します"
+  end
+end
+
 puts "\n=== Estate Match 初期データ読み込み完了 ==="
 puts "管理者ログイン情報:"
 puts "  メール: estate.admin.2024@secure.local"
 puts "  パスワード: EstateAdmin#2024!Secure"
 puts "  管理者パスワード: EstateSecure@Admin2024#Panel"
+puts "\nサンプル不動産業者:"
+puts "  田中不動産: tanaka@sample-estate.com / password123"
+puts "  プレミアム不動産: sato@premium-estate.com / password123"
+puts "\nサンプルオーナー:"
+puts "  山田一郎: yamada@example.com / password123"
+puts "  鈴木二郎: suzuki@example.com / password123"

--- a/spec/factories/inquiries.rb
+++ b/spec/factories/inquiries.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :inquiry do
+    property { nil }
+    buyer { nil }
+    agent { nil }
+    status { 1 }
+    message { "MyText" }
+  end
+end

--- a/spec/factories/membership_plans.rb
+++ b/spec/factories/membership_plans.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :membership_plan do
+    name { "MyString" }
+    monthly_owner_limit { 1 }
+    monthly_price { 1 }
+    features { "MyText" }
+    active { false }
+  end
+end

--- a/spec/factories/partnerships.rb
+++ b/spec/factories/partnerships.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :partnership do
+    agent { nil }
+    owner { nil }
+    status { 1 }
+    started_at { "2025-08-15 23:36:21" }
+    ended_at { "2025-08-15 23:36:21" }
+    commission_rate { "9.99" }
+  end
+end

--- a/spec/models/inquiry_spec.rb
+++ b/spec/models/inquiry_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Inquiry, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/membership_plan_spec.rb
+++ b/spec/models/membership_plan_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe MembershipPlan, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/partnership_spec.rb
+++ b/spec/models/partnership_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Partnership, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
空き家・空き地マッチングサービスに不動産業者機能を追加。
3者間（購入者・不動産業者・オーナー）のマッチングシステムの基盤を構築。

## 実装内容
- **ユーザータイプ拡張**: `agent`（不動産業者）をenum値2で追加
- **会員プランシステム**: 月間メッセージ制限付きの4段階プラン
- **パートナーシップシステム**: 不動産業者⇔オーナー間の提携関係管理
- **問い合わせシステム**: 一般ユーザーの「話を聞いてみる」機能準備

## 新規モデル
### MembershipPlan
- 会員プラン管理（フリー・ベーシック・プレミアム・エンタープライズ）
- 月間メッセージ制限数・料金・機能設定

### Partnership
- 不動産業者⇔オーナーのパートナーシップ管理
- ステータス管理（申請中・有効・無効・終了）
- 手数料率・契約期間管理

### Inquiry
- 一般ユーザーの「話を聞いてみる」問い合わせ
- ステータス管理（待機・連絡済み・完了）
- 自動的な不動産業者ルーティング準備

## Userモデル拡張
- **agent**ユーザータイプ追加
- 不動産業者専用フィールド（会社名・免許番号）
- 月間メッセージ制限機能
- パートナーシップ管理メソッド

## 初期データ
- 4つの会員プラン作成
- サンプル不動産業者（田中不動産・プレミアム不動産）
- サンプルオーナー作成

## 技術詳細
- Rails 8.0対応（serialize記法更新）
- 外部キー制約・インデックス最適化
- バリデーション・カスタムバリデーション実装
- enum活用による状態管理

## 今後の実装予定
- メッセージ権限システム
- 不動産業者向けUI
- 一般ユーザー向け問い合わせ機能
- 管理画面での新機能対応

🤖 Generated with [Claude Code](https://claude.ai/code)