### PR TITLE
feat: 不動産業者新規登録機能と未読メッセージ表示機能の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,12 +36,12 @@ class ApplicationController < ActionController::Base
   protected
 
   # Deviseのストロングパラメータ設定
-  # デフォルトのemail, passwordに加えて、name, user_typeを許可
+  # デフォルトのemail, passwordに加えて、name, user_type、不動産業者向けフィールドを許可
   def configure_permitted_parameters
     # ユーザー登録時に許可するパラメータ
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :user_type])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :user_type, :company_name, :license_number, :membership_plan_id])
     # アカウント更新時に許可するパラメータ
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :user_type])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :user_type, :company_name, :license_number, :membership_plan_id])
   end
 
   # ログイン成功後のリダイレクト先を指定

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -100,7 +100,7 @@ class ConversationsController < ApplicationController
     end
     
     if @conversation.persisted?
-      redirect_to @conversation, notice: 'オーナーとの会話を開始しました。'
+      redirect_to @conversation
     else
       redirect_to @property, alert: "会話の作成に失敗しました: #{@conversation.errors.full_messages.join(', ')}"
     end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,25 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  private
+
+  # 登録成功後のリダイレクト先を指定
+  def after_sign_up_path_for(resource)
+    if resource.agent?
+      # 不動産業者の場合はウェルカムメッセージ付きでダッシュボードへ
+      flash[:notice] = build_agent_welcome_message(resource)
+      dashboard_path
+    else
+      # その他のユーザータイプは通常通り
+      super
+    end
+  end
+
+  # 不動産業者向けウェルカムメッセージを作成
+  def build_agent_welcome_message(user)
+    plan_name = user.membership_plan&.name || '未選択'
+    "🎉 不動産業者として登録が完了しました！\n" \
+    "会社名: #{user.company_name}\n" \
+    "免許番号: #{user.license_number}\n" \
+    "選択プラン: #{plan_name}\n\n" \
+    "今すぐオーナーの方にメッセージを送信して、優良物件の仲介を始めましょう！"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -173,6 +173,35 @@ class User < ApplicationRecord
     end
   end
 
+  # 未読メッセージ件数を取得
+  def unread_messages_count
+    case user_type
+    when 'agent'
+      # 不動産業者の場合：agent_ownerタイプの会話での未読メッセージ
+      Message.joins(:conversation)
+             .where(conversations: { agent_id: id, conversation_type: 'agent_owner' })
+             .where.not(sender_id: id)
+             .where(read_at: nil)
+             .count
+    when 'owner'
+      # オーナーの場合：自分がオーナーの会話での未読メッセージ
+      Message.joins(:conversation)
+             .where(conversations: { owner_id: id })
+             .where.not(sender_id: id)
+             .where(read_at: nil)
+             .count
+    when 'buyer'
+      # 購入希望者の場合：自分がbuyerの会話での未読メッセージ
+      Message.joins(:conversation)
+             .where(conversations: { buyer_id: id })
+             .where.not(sender_id: id)
+             .where(read_at: nil)
+             .count
+    else
+      0
+    end
+  end
+
   def pending_partnership_requests
     case user_type
     when 'agent'

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -206,21 +206,12 @@
           <div class="text-estate-dark-500">会話数</div>
         </div>
         
-        <% if current_user.agent? %>
-          <div class="bg-white rounded-xl shadow-sm p-6 text-center">
-            <div class="text-2xl font-bold text-blue-600 mb-2">
-              <%= current_user.monthly_message_count %>
-            </div>
-            <div class="text-estate-dark-500">今月のメッセージ</div>
+        <div class="bg-white rounded-xl shadow-sm p-6 text-center">
+          <div class="text-2xl font-bold text-estate-gold-600 mb-2">
+            <%= current_user.unread_messages_count %>
           </div>
-        <% else %>
-          <div class="bg-white rounded-xl shadow-sm p-6 text-center">
-            <div class="text-2xl font-bold text-estate-gold-600 mb-2">
-              <%= current_user.unread_messages_count %>
-            </div>
-            <div class="text-estate-dark-500">未読メッセージ</div>
-          </div>
-        <% end %>
+          <div class="text-estate-dark-500">未読メッセージ</div>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -29,10 +29,59 @@
           <%= f.select :user_type, 
                        options_for_select([
                          ['物件を探したい（購入希望者）', 'buyer'],
-                         ['物件を登録したい（オーナー）', 'owner']
+                         ['物件を登録したい（オーナー）', 'owner'],
+                         ['不動産業者として登録', 'agent']
                        ], 'buyer'),
                        {},
                        { class: "appearance-none rounded-lg relative block w-full px-3 py-3 border border-estate-warm-400 text-estate-dark-900 focus:outline-none focus:ring-estate-primary-500 focus:border-estate-primary-500 bg-white" } %>
+        </div>
+
+        <!-- Agent-specific Fields (hidden by default) -->
+        <div id="agent-fields" class="space-y-4" style="display: none;">
+          <!-- Company Name Field -->
+          <div>
+            <%= f.label :company_name, "会社名", class: "block text-sm font-medium text-estate-dark-700 mb-2" %>
+            <%= f.text_field :company_name, 
+                             id: "agent_company_name",
+                             class: "appearance-none rounded-lg relative block w-full px-3 py-3 border border-estate-warm-400 placeholder-estate-dark-300 text-estate-dark-900 focus:outline-none focus:ring-estate-primary-500 focus:border-estate-primary-500 focus:z-10",
+                             placeholder: "株式会社◯◯不動産" %>
+          </div>
+
+          <!-- License Number Field -->
+          <div>
+            <%= f.label :license_number, "宅地建物取引業免許番号", class: "block text-sm font-medium text-estate-dark-700 mb-2" %>
+            <%= f.text_field :license_number, 
+                             id: "agent_license_number",
+                             class: "appearance-none rounded-lg relative block w-full px-3 py-3 border border-estate-warm-400 placeholder-estate-dark-300 text-estate-dark-900 focus:outline-none focus:ring-estate-primary-500 focus:border-estate-primary-500 focus:z-10",
+                             placeholder: "東京都知事(1)第12345号" %>
+            <p class="text-xs text-estate-dark-500 mt-1">宅地建物取引業の免許番号を正確に入力してください</p>
+          </div>
+
+          <!-- Membership Plan Selection -->
+          <div>
+            <%= f.label :membership_plan_id, "会員プラン", class: "block text-sm font-medium text-estate-dark-700 mb-2" %>
+            <%= f.select :membership_plan_id,
+                         options_from_collection_for_select(MembershipPlan.active.ordered, :id, :name),
+                         { prompt: 'プランを選択してください' },
+                         { id: "agent_membership_plan", class: "appearance-none rounded-lg relative block w-full px-3 py-3 border border-estate-warm-400 text-estate-dark-900 focus:outline-none focus:ring-estate-primary-500 focus:border-estate-primary-500 bg-white" } %>
+            <p class="text-xs text-estate-dark-500 mt-1">後から変更することも可能です</p>
+          </div>
+
+          <!-- Membership Plans Information -->
+          <div class="bg-estate-warm-50 rounded-lg p-4">
+            <h4 class="font-medium text-estate-dark-800 mb-2">💡 会員プラン比較</h4>
+            <div class="space-y-2 text-sm text-estate-dark-600">
+              <% MembershipPlan.active.ordered.each do |plan| %>
+                <div class="flex justify-between items-center">
+                  <span class="font-medium"><%= plan.name %></span>
+                  <div class="text-right">
+                    <span class="text-estate-primary-600 font-bold"><%= plan.formatted_price %></span>
+                    <span class="text-xs block">月<%= plan.monthly_property_limit %>物件まで</span>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          </div>
         </div>
 
         <!-- Email Field -->
@@ -83,3 +132,79 @@
     </div>
   </div>
 </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const userTypeSelect = document.querySelector('select[name="user[user_type]"]');
+  const agentFields = document.getElementById('agent-fields');
+  
+  function toggleAgentFields() {
+    const companyNameField = document.getElementById('agent_company_name');
+    const licenseNumberField = document.getElementById('agent_license_number');
+    const membershipPlanField = document.getElementById('agent_membership_plan');
+    
+    if (userTypeSelect.value === 'agent') {
+      console.log('Showing agent fields'); // Debug
+      agentFields.style.display = 'block';
+      agentFields.style.opacity = '0';
+      agentFields.style.transform = 'translateY(-10px)';
+      
+      // Set required attributes
+      if (companyNameField) companyNameField.required = true;
+      if (licenseNumberField) licenseNumberField.required = true;
+      if (membershipPlanField) membershipPlanField.required = true;
+      
+      // Smooth animation
+      setTimeout(() => {
+        agentFields.style.transition = 'all 0.3s ease-in-out';
+        agentFields.style.opacity = '1';
+        agentFields.style.transform = 'translateY(0)';
+      }, 10);
+    } else {
+      console.log('Hiding agent fields'); // Debug
+      agentFields.style.transition = 'all 0.3s ease-in-out';
+      agentFields.style.opacity = '0';
+      agentFields.style.transform = 'translateY(-10px)';
+      
+      // Remove required attributes
+      if (companyNameField) companyNameField.required = false;
+      if (licenseNumberField) licenseNumberField.required = false;
+      if (membershipPlanField) membershipPlanField.required = false;
+      
+      setTimeout(() => {
+        if (userTypeSelect.value !== 'agent') {
+          agentFields.style.display = 'none';
+        }
+      }, 300);
+    }
+  }
+  
+  // Initial check
+  toggleAgentFields();
+  
+  // Listen for changes
+  userTypeSelect.addEventListener('change', toggleAgentFields);
+  
+  // Debug form submission
+  const form = document.querySelector('form');
+  if (form) {
+    form.addEventListener('submit', function(e) {
+      if (userTypeSelect.value === 'agent') {
+        const companyName = document.getElementById('agent_company_name').value;
+        const licenseNumber = document.getElementById('agent_license_number').value;
+        const membershipPlan = document.getElementById('agent_membership_plan').value;
+        
+        console.log('Submitting agent form with:', {
+          company_name: companyName,
+          license_number: licenseNumber,
+          membership_plan_id: membershipPlan
+        });
+        
+        if (!companyName || !licenseNumber || !membershipPlan) {
+          console.warn('Required agent fields are missing!');
+        }
+      }
+    });
+  }
+});
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: 'users/registrations'
+  }
   root "pages#index"
   get "pages/index"
   

--- a/spec/requests/agent_registration_spec.rb
+++ b/spec/requests/agent_registration_spec.rb
@@ -1,0 +1,138 @@
+require 'rails_helper'
+
+RSpec.describe "Agent Registration", type: :request do
+  let(:membership_plan) { create(:membership_plan) }
+  
+  describe "POST /users" do
+    context "when registering as an agent" do
+      let(:agent_params) do
+        {
+          user: {
+            name: "山田太郎",
+            email: "agent@example.com",
+            password: "password123",
+            password_confirmation: "password123",
+            user_type: "agent",
+            company_name: "山田不動産株式会社",
+            license_number: "東京都知事(1)第12345号",
+            membership_plan_id: membership_plan.id
+          }
+        }
+      end
+
+      it "creates a new agent user successfully" do
+        expect {
+          post user_registration_path, params: agent_params
+        }.to change(User, :count).by(1)
+        
+        user = User.last
+        expect(user.agent?).to be true
+        expect(user.company_name).to eq("山田不動産株式会社")
+        expect(user.license_number).to eq("東京都知事(1)第12345号")
+        expect(user.membership_plan).to eq(membership_plan)
+      end
+
+      it "redirects to dashboard with welcome message" do
+        post user_registration_path, params: agent_params
+        
+        expect(response).to redirect_to(dashboard_path)
+        follow_redirect!
+        
+        expect(flash[:notice]).to include("不動産業者として登録が完了しました")
+        expect(flash[:notice]).to include("山田不動産株式会社")
+        expect(flash[:notice]).to include("東京都知事(1)第12345号")
+      end
+
+      context "when required agent fields are missing" do
+        it "fails validation without company_name" do
+          agent_params[:user][:company_name] = ""
+          
+          expect {
+            post user_registration_path, params: agent_params
+          }.not_to change(User, :count)
+        end
+
+        it "fails validation without license_number" do
+          agent_params[:user][:license_number] = ""
+          
+          expect {
+            post user_registration_path, params: agent_params
+          }.not_to change(User, :count)
+        end
+
+        it "fails validation without membership_plan" do
+          agent_params[:user][:membership_plan_id] = ""
+          
+          expect {
+            post user_registration_path, params: agent_params
+          }.not_to change(User, :count)
+        end
+      end
+    end
+
+    context "when registering as buyer or owner" do
+      let(:buyer_params) do
+        {
+          user: {
+            name: "佐藤花子",
+            email: "buyer@example.com",
+            password: "password123",
+            password_confirmation: "password123",
+            user_type: "buyer"
+          }
+        }
+      end
+
+      it "creates buyer without agent-specific fields" do
+        expect {
+          post user_registration_path, params: buyer_params
+        }.to change(User, :count).by(1)
+        
+        user = User.last
+        expect(user.buyer?).to be true
+        expect(user.company_name).to be_nil
+        expect(user.license_number).to be_nil
+        expect(user.membership_plan).to be_nil
+      end
+
+      it "uses standard redirect for non-agent users" do
+        post user_registration_path, params: buyer_params
+        
+        expect(response).to redirect_to(dashboard_path)
+        follow_redirect!
+        
+        expect(flash[:notice]).not_to include("不動産業者として登録が完了しました")
+      end
+    end
+  end
+
+  describe "GET /users/sign_up" do
+    it "displays the registration form with agent option" do
+      get new_user_registration_path
+      
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("不動産業者として登録")
+      expect(response.body).to include("会社名")
+      expect(response.body).to include("宅地建物取引業免許番号")
+      expect(response.body).to include("会員プラン")
+    end
+
+    it "includes JavaScript for dynamic field toggling" do
+      get new_user_registration_path
+      
+      expect(response.body).to include("toggleAgentFields")
+      expect(response.body).to include("agent-fields")
+    end
+
+    it "shows membership plan comparison" do
+      create(:membership_plan, name: "ベーシックプラン", monthly_property_limit: 10)
+      create(:membership_plan, name: "プレミアムプラン", monthly_property_limit: 30)
+      
+      get new_user_registration_path
+      
+      expect(response.body).to include("会員プラン比較")
+      expect(response.body).to include("ベーシックプラン")
+      expect(response.body).to include("プレミアムプラン")
+    end
+  end
+end

--- a/spec/requests/conversations_spec.rb
+++ b/spec/requests/conversations_spec.rb
@@ -115,10 +115,11 @@ RSpec.describe 'Conversations', type: :request do
           expect(response).to redirect_to(conversation)
         end
 
-        it 'displays success message' do
+        it 'redirects without notification message' do
           post conversations_path, params: { property_id: property.id }
+          expect(response).to redirect_to(Conversation.last)
           follow_redirect!
-          expect(response.body).to include('オーナーとの会話を開始しました')
+          expect(response).to have_http_status(:success)
         end
       end
 


### PR DESCRIPTION
## 概要
不動産業者が直接サインアップできる機能と、業者向け未読メッセージ表示機能を実装。

## 実装内容
- **不動産業者新規登録**: 業者選択時の動的フォーム表示機能
- **カスタム登録フロー**: 業者専用ウェルカムメッセージとリダイレクト
- **未読メッセージ統一表示**: 全ユーザータイプで未読メッセージ数を表示
- **不要な通知削除**: 会話開始時の不要な通知メッセージを削除

## 技術詳細
- **Devise**: カスタムregistrationsコントローラーの実装
- **JavaScript**: 動的フォームフィールド切り替え機能
- **Strong Parameters**: 業者固有フィールドの許可設定
- **ユーザーモデル**: 統一的な未読メッセージカウント機能

## UI/UX改善
- 業者選択時のスムーズなアニメーション
- 会員プラン比較情報の表示
- 統一感のある未読メッセージ表示

## 主要ファイル
### モデル
- `app/models/user.rb` - 未読メッセージカウント機能の統一

### コントローラー
- `app/controllers/users/registrations_controller.rb` - カスタム登録フロー
- `app/controllers/application_controller.rb` - Strong Parameters設定
- `app/controllers/conversations_controller.rb` - 不要な通知削除

### ビュー
- `app/views/devise/registrations/new.html.erb` - 動的業者登録フォーム
- `app/views/dashboard/index.html.erb` - 統一未読メッセージ表示

## テスト内容
- [x] 業者登録フローの正常系・異常系テスト
- [x] 動的フォーム表示のテスト
- [x] ウェルカムメッセージのテスト
- [x] 会話作成時の通知削除確認

🤖 Generated with [Claude Code](https://claude.ai/code)